### PR TITLE
feat(git): add conventional commits commit-msg hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,16 @@ stow -t ~ doom        # .doom.d to home
 - macOS: `~/Library/Application Support/nushell/`
 - Arch: `~/.config/nushell/`
 
+## Commit Convention
+
+This repo uses **Conventional Commits** enforced by a `commit-msg` hook in `git/hooks/`.
+
+Format: `type(scope): description` or `type: description`
+
+Allowed types: `feat` `fix` `chore` `docs` `style` `refactor` `test` `ci` `build` `perf`
+
+Run `just setup-hooks` (or `just mac` / `just arch`) to activate the hook via `core.hooksPath`.
+
 ## Architecture
 
 ### Directory Structure

--- a/git/hooks/commit-msg
+++ b/git/hooks/commit-msg
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Conventional Commits commit-msg hook
+# Format: type(scope): description  OR  type: description
+# Allowed types: feat fix chore docs style refactor test ci build perf
+
+commit_msg_file="$1"
+commit_msg=$(head -1 "$commit_msg_file")
+
+# Allow merge commits, reverts, fixups, and squashes
+if echo "$commit_msg" | grep -qE '^(Merge |Revert |fixup! |squash! |amend! )'; then
+  exit 0
+fi
+
+types="feat|fix|chore|docs|style|refactor|test|ci|build|perf"
+pattern="^($types)(\(.+\))?: .+"
+
+if ! echo "$commit_msg" | grep -qE "$pattern"; then
+  echo "ERROR: Commit message does not follow Conventional Commits format."
+  echo ""
+  echo "  Expected: type(scope): description"
+  echo "       or:  type: description"
+  echo ""
+  echo "  Allowed types: feat fix chore docs style refactor test ci build perf"
+  echo ""
+  echo "  Examples:"
+  echo "    feat(nvim): add telescope keybinding"
+  echo "    fix: correct stow target path"
+  echo "    chore: update package list"
+  echo ""
+  echo "  Your message: $commit_msg"
+  exit 1
+fi

--- a/justfile
+++ b/justfile
@@ -2,9 +2,9 @@ set shell := ["bash", "-euo", "pipefail", "-c"]
 
 os := `uname -s`
 
-mac: brew stow-mac rust
+mac: brew stow-mac rust setup-hooks
 
-arch: pacman stow-arch rust
+arch: pacman stow-arch rust setup-hooks
 
 rust:
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -21,6 +21,27 @@ stow-common:
     stow nvim
     stow -t ~ tmux
     stow -t ~ zoxide
+    local_bin="$$HOME/.local/bin"
+    mkdir -p "$local_bin"
+
+    existing=""
+    for f in bin/*; do
+      [ -e "$local_bin/$(basename "$f")" ] || continue
+      name="$(basename "$f")"
+
+      escaped="$(printf '%s' "$name" | sed -e 's/[.\\^$*+?(){}|\[\]\\\\]/\\&/g')"
+      if [ -n "$existing" ]; then
+        existing+="|$escaped"
+      else
+        existing="$escaped"
+      fi
+    done
+
+    if [ -n "$existing" ]; then
+      stow -t "$local_bin" --ignore="^($existing)$" bin
+    else
+      stow -t "$local_bin" bin
+    fi
 
 stow-nushell-mac:
     stow -t "$HOME/Library/Application Support/nushell" nushell
@@ -53,6 +74,9 @@ check-stow-mac:
     mkdir -p "$$HOME/Library/Application Support/nushell"
     stow -n -v yazi
     stow -n -v -t "$$HOME/Library/Application Support/nushell" nushell
+
+setup-hooks:
+    git config core.hooksPath git/hooks
 
 check-stow-arch:
     mkdir -p "$$HOME/.config/nushell"

--- a/justfile
+++ b/justfile
@@ -21,27 +21,6 @@ stow-common:
     stow nvim
     stow -t ~ tmux
     stow -t ~ zoxide
-    local_bin="$$HOME/.local/bin"
-    mkdir -p "$local_bin"
-
-    existing=""
-    for f in bin/*; do
-      [ -e "$local_bin/$(basename "$f")" ] || continue
-      name="$(basename "$f")"
-
-      escaped="$(printf '%s' "$name" | sed -e 's/[.\\^$*+?(){}|\[\]\\\\]/\\&/g')"
-      if [ -n "$existing" ]; then
-        existing+="|$escaped"
-      else
-        existing="$escaped"
-      fi
-    done
-
-    if [ -n "$existing" ]; then
-      stow -t "$local_bin" --ignore="^($existing)$" bin
-    else
-      stow -t "$local_bin" bin
-    fi
 
 stow-nushell-mac:
     stow -t "$HOME/Library/Application Support/nushell" nushell

--- a/yazi/.config/yazi/yazi.toml
+++ b/yazi/.config/yazi/yazi.toml
@@ -1,2 +1,3 @@
 [mgr]
 ratio = [0, 4, 3]
+show_hidden = true

--- a/yazi/.config/yazi/yazi.toml
+++ b/yazi/.config/yazi/yazi.toml
@@ -1,3 +1,2 @@
 [mgr]
 ratio = [0, 4, 3]
-show_hidden = true


### PR DESCRIPTION
## Summary
- Add a `commit-msg` git hook in `git/hooks/` that enforces conventional commits format (`type(scope): description`)
- Add `setup-hooks` just recipe that configures `core.hooksPath` to use managed hooks
- Integrate `setup-hooks` into `mac` and `arch` setup recipes
- Document the commit convention in `CLAUDE.md`

## Test plan
- [x] Hook rejects non-conforming commit messages (exit 1)
- [x] Hook accepts valid conventional commit messages (exit 0)
- [x] Hook allows merge commits, reverts, fixups, squashes, and amends
- [x] `just setup-hooks` activates the hook via `core.hooksPath`
- [x] All 10 types validated: feat fix chore docs style refactor test ci build perf
- [x] Edge cases: missing space after colon, empty description, invalid type all rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: commit-normalize:/
task-type: commit-normalize
task-title: Commit Message Normalizer
provider: claude
nightshift:metadata -->