### PR TITLE
feat: add commit message normalizer

### DIFF
--- a/bin/commit-normalize
+++ b/bin/commit-normalize
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# commit-normalize: lint a commit message string against conventional commit format
+# Usage: commit-normalize "your commit message"
+#        echo "your commit message" | commit-normalize
+
+set -euo pipefail
+
+if [ $# -gt 0 ]; then
+    MSG="$1"
+elif [ ! -t 0 ]; then
+    MSG=$(head -1)
+else
+    echo "Usage: commit-normalize \"your commit message\""
+    echo "       echo \"your commit message\" | commit-normalize"
+    exit 1
+fi
+
+TYPES="feat|fix|docs|chore|refactor|style|test|build|ci|perf"
+PATTERN="^($TYPES)(\([a-zA-Z0-9_-]+\))?: .{1,}"
+
+VAGUE_PATTERNS="^(updates?|fix|fixes|fixed|changes?|changed|stuff|wip|tmp|temp|asdf|test|minor|misc|cleanup)$"
+if echo "$MSG" | grep -iqE "$VAGUE_PATTERNS"; then
+    echo "FAIL: Message is too vague: '$MSG'"
+    echo "Use a descriptive conventional commit message instead."
+    exit 1
+fi
+
+if echo "$MSG" | grep -qE "$PATTERN"; then
+    echo "OK: '$MSG'"
+    exit 0
+else
+    echo "FAIL: '$MSG'"
+    echo ""
+    echo "Expected format: type(scope): description"
+    echo "Valid types: feat, fix, docs, chore, refactor, style, test, build, ci, perf"
+    exit 1
+fi

--- a/githooks/.config/git/hooks/commit-msg
+++ b/githooks/.config/git/hooks/commit-msg
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# commit-msg hook: validates commit messages against conventional commit format
+
+set -euo pipefail
+
+COMMIT_MSG_FILE="$1"
+COMMIT_MSG=$(head -1 "$COMMIT_MSG_FILE")
+
+# Skip merge commits and fixup/squash commits
+if echo "$COMMIT_MSG" | grep -qE '^(Merge|Revert|fixup!|squash!)'; then
+    exit 0
+fi
+
+# Valid conventional commit types
+TYPES="feat|fix|docs|chore|refactor|style|test|build|ci|perf"
+
+# Conventional commit pattern: type(optional-scope): description
+PATTERN="^($TYPES)(\([a-zA-Z0-9_-]+\))?: .{1,}"
+
+if ! echo "$COMMIT_MSG" | grep -qE "$PATTERN"; then
+    # Check for vague one-word messages
+    VAGUE_PATTERNS="^(updates?|fix|fixes|fixed|changes?|changed|stuff|wip|tmp|temp|asdf|test|minor|misc|cleanup)$"
+    if echo "$COMMIT_MSG" | grep -iqE "$VAGUE_PATTERNS"; then
+        echo "ERROR: Commit message is too vague: '$COMMIT_MSG'"
+        echo ""
+        echo "Please use a descriptive conventional commit message."
+    else
+        echo "ERROR: Commit message does not follow conventional commit format."
+    fi
+    echo ""
+    echo "Expected format: type(scope): description"
+    echo ""
+    echo "Valid types: feat, fix, docs, chore, refactor, style, test, build, ci, perf"
+    echo ""
+    echo "Examples:"
+    echo "  feat: add user authentication"
+    echo "  fix(parser): handle empty input"
+    echo "  docs: update API reference"
+    echo "  chore(deps): bump lodash to 4.17.21"
+    exit 1
+fi

--- a/githooks/.config/git/hooks/prepare-commit-msg
+++ b/githooks/.config/git/hooks/prepare-commit-msg
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# prepare-commit-msg hook: prepopulates commit message template with conventional commit hint
+
+set -euo pipefail
+
+COMMIT_MSG_FILE="$1"
+COMMIT_SOURCE="${2:-}"
+
+# Only add template for new commits (not merges, amends, squashes, etc.)
+if [ -z "$COMMIT_SOURCE" ]; then
+    EXISTING=$(cat "$COMMIT_MSG_FILE")
+    cat > "$COMMIT_MSG_FILE" <<'EOF'
+
+# Conventional Commit Format: type(scope): description
+#
+# Types: feat, fix, docs, chore, refactor, style, test, build, ci, perf
+#
+# Examples:
+#   feat: add user authentication
+#   fix(parser): handle empty input
+#   docs: update API reference
+EOF
+    echo "$EXISTING" >> "$COMMIT_MSG_FILE"
+fi

--- a/justfile
+++ b/justfile
@@ -28,9 +28,14 @@ stow-nushell-mac:
 stow-nushell-arch:
     stow -t "$HOME/.config/nushell" nushell
 
-stow-mac: stow-common stow-nushell-mac
+stow-githooks:
+    mkdir -p "$HOME/.config/git/hooks"
+    stow githooks
+    git config --global core.hooksPath "$HOME/.config/git/hooks"
 
-stow-arch: stow-common stow-nushell-arch
+stow-mac: stow-common stow-nushell-mac stow-githooks
+
+stow-arch: stow-common stow-nushell-arch stow-githooks
     stow hypr
     stow uwsm
 


### PR DESCRIPTION
## Summary
- Add `commit-msg` hook that validates messages against conventional commit format (feat/fix/docs/chore/refactor/style/test/build/ci/perf with optional scope)
- Add `prepare-commit-msg` hook that prepopulates the template with format hints
- Add standalone `bin/commit-normalize` script for linting messages outside hooks
- Add `stow-githooks` justfile target to install hooks via stow, integrated into `stow-mac` and `stow-arch`

## Test plan
- [x] `commit-normalize "feat: add auth"` → OK
- [x] `commit-normalize "fix(parser): handle empty"` → OK
- [x] `commit-normalize "updates"` → FAIL (vague)
- [x] `commit-normalize "fix"` → FAIL (vague, not confused with valid type)
- [x] `commit-normalize "random bad message"` → FAIL (not conventional format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)